### PR TITLE
Future-proof a dependency on type inference

### DIFF
--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -378,7 +378,7 @@ impl Estimator for SpatialEstimator {
                 if unshifted_count == 0 {
                     guesses *= 2;
                 } else {
-                    let shifted_variations = (1..(cmp::min(shifted_count, unshifted_count) + 1))
+                    let shifted_variations: u64 = (1..(cmp::min(shifted_count, unshifted_count) + 1))
                         .into_iter()
                         .map(|i| n_ck(shifted_count + unshifted_count, i))
                         .sum();


### PR DESCRIPTION
In the Rust compiler, a pull request is being considered (see GitHub PR rust-lang/rust#41336) that will add support for `a *= &b` (instead of only `a *= b`) for numeric types like `i64` and `f64`. This helps when writing generic code.

Unfortunately, this breaks the build of zxcvbn, because zxcvbn currently does the following in scoring.rs:

```
let shifted_variations = (1..(cmp::min(shifted_count, unshifted_count) + 1))
    .into_iter()
    .map(|i| n_ck(shifted_count + unshifted_count, i))
    .sum();
guesses *= shifted_variations;
```

Rust is currently able to infer that the type of `shifted_variations` must be `u64`, because it gets multiplied (with `*=`) to a `u64`. But if the PR on the compiler is accepted, this type inference will no longer be possible, because the type of `shifted_variations` could then also be `&'a u64` for some lifetime `'a`.

This commit specifies the type of `shifted_variations` explicitly, so that it doesn't require any type inference.