### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ extern crate zxcvbn;
 use zxcvbn::zxcvbn;
 
 fn main() {
-    let estimate = zxcvbn("correcthorsebatterystaple", None).unwrap();
+    let estimate = zxcvbn("correcthorsebatterystaple", &[]).unwrap();
     println!("{}", estimate.score); // 3
 }
 ```


### PR DESCRIPTION
The current code causes the following compilation error:

```
let estimate = zxcvbn("correcthorsebatterystaple", None).unwrap();
   |                                ^^^^ expected &[&str], found enum `std::option::Option`
```

The proposed changes fix it.