### PR TITLE
Align JSON output with original library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ version = "1.0.0"
 
 [dev-dependencies]
 quickcheck = "0.6.0"
-serde_json = "1.0.0"
+serde_json = "1.0.21"
 
 [features]
 default = []

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -19,6 +19,7 @@ pub struct Match {
     /// Token that has been matched.
     pub token: String,
     /// Pattern type and details used to detect this match.
+    #[cfg_attr(feature = "ser", serde(flatten))]
     pub pattern: MatchPattern,
     /// Estimated number of tries for guessing the match.
     pub guesses: Option<u64>,
@@ -197,7 +198,7 @@ impl Matcher for L33tMatch {
                         match_sub
                             .iter()
                             .map(|(k, v)| format!("{} -> {}", k, v))
-                            .collect(),
+                            .join(", "),
                     );
                     pattern.sub = Some(match_sub);
                 }

--- a/src/matching/patterns.rs
+++ b/src/matching/patterns.rs
@@ -4,6 +4,8 @@ use matching::Match;
 /// Pattern type used to detect a match
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(Serialize))]
+#[cfg_attr(feature = "ser", serde(tag="pattern"))]
+#[cfg_attr(feature = "ser", serde(rename_all="lowercase"))]
 pub enum MatchPattern {
     /// A match based on a word in a dictionary
     Dictionary(DictionaryPattern),

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -10,7 +10,7 @@ pub struct GuessCalculation {
     /// Estimated guesses needed to crack the password
     pub guesses: u64,
     /// Order of magnitude of `guesses`
-    pub guesses_log10: u16,
+    pub guesses_log10: f64,
     /// The list of patterns the guess calculation was based on
     pub sequence: Vec<Match>,
 }
@@ -196,7 +196,7 @@ pub fn most_guessable_match_sequence(
 
     GuessCalculation {
         guesses: guesses as u64,
-        guesses_log10: (guesses as f64).log10() as u16,
+        guesses_log10: (guesses as f64).log10(),
         sequence: optimal_match_sequence,
     }
 }

--- a/src/time_estimates.rs
+++ b/src/time_estimates.rs
@@ -9,16 +9,16 @@ pub struct CrackTimes {
     pub online_throttling_100_per_hour: u64,
     /// Online attack on a service that doesn't rate-limit,
     /// or where an attacker has outsmarted rate-limiting.
-    pub online_no_throttling_10_per_second: u64,
+    pub online_no_throttling_10_per_second: f64,
     /// Offline attack, assumes multiple attackers.
     /// Proper user-unique salting, and a slow hash function
     /// such as bcrypt, scrypt, PBKDF2.
-    pub offline_slow_hashing_1e4_per_second: u64,
+    pub offline_slow_hashing_1e4_per_second: f64,
     /// Offline attack with user-unique salting but a fast hash function
     /// such as SHA-1, SHA-256, or MD5. A wide range of reasonable numbers
     /// anywhere from one billion to one trillion guesses per second,
     /// depending on number of cores and machines, ballparking at 10 billion per second.
-    pub offline_fast_hashing_1e10_per_second: u64,
+    pub offline_fast_hashing_1e10_per_second: f64,
 }
 
 /// Back-of-the-envelope crack time estimations, in a human-readable format,
@@ -44,24 +44,25 @@ pub struct CrackTimesDisplay {
 
 #[doc(hidden)]
 pub fn estimate_attack_times(guesses: u64) -> (CrackTimes, CrackTimesDisplay, u8) {
+    let guesses_f64 = guesses as f64;
     let crack_times_seconds = CrackTimes {
         online_throttling_100_per_hour: guesses.saturating_mul(36),
-        online_no_throttling_10_per_second: guesses / 10,
-        offline_slow_hashing_1e4_per_second: guesses / 10_000,
-        offline_fast_hashing_1e10_per_second: guesses / 10_000_000_000,
+        online_no_throttling_10_per_second: guesses_f64 / 10.00,
+        offline_slow_hashing_1e4_per_second: guesses_f64 / 10_000.00,
+        offline_fast_hashing_1e10_per_second: guesses_f64 / 10_000_000_000.00,
     };
     let crack_times_display = CrackTimesDisplay {
         online_throttling_100_per_hour: display_time(
-            crack_times_seconds.online_throttling_100_per_hour,
+            crack_times_seconds.online_throttling_100_per_hour as u64,
         ),
         online_no_throttling_10_per_second: display_time(
-            crack_times_seconds.online_no_throttling_10_per_second,
+            crack_times_seconds.online_no_throttling_10_per_second as u64,
         ),
         offline_slow_hashing_1e4_per_second: display_time(
-            crack_times_seconds.offline_slow_hashing_1e4_per_second,
+            crack_times_seconds.offline_slow_hashing_1e4_per_second as u64,
         ),
         offline_fast_hashing_1e10_per_second: display_time(
-            crack_times_seconds.offline_fast_hashing_1e10_per_second,
+            crack_times_seconds.offline_fast_hashing_1e10_per_second as u64,
         ),
     };
     (


### PR DESCRIPTION
To be more consistent with the original library result, `pattern` field in `struct Match` is flattened and `enum MatchPattern` type lowercased and moved to `pattern` field through [serde's attributes](https://serde.rs/attributes.html),  while `sub_display` is a join of `match_sub` values with `", "` using [itertools::Itertools::join](https://docs.rs/itertools/0.7.8/itertools/trait.Itertools.html#method.join).
