### PR TITLE
Add Send trait marker

### DIFF
--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -64,7 +64,7 @@ lazy_static! {
     };
 }
 
-trait Matcher: Sync {
+trait Matcher: Send + Sync {
     fn get_matches(&self, password: &str, user_inputs: &HashMap<String, usize>) -> Vec<Match>;
 }
 


### PR DESCRIPTION
Hi, after upgrading some dependencies of a project I'm working on I received the following compilation error:

```
error[E0277]: `(dyn matching::Matcher + 'static)` cannot be sent between threads safely
  --> /home/sam/.cargo/git/checkouts/zxcvbn-rs-e38ddaa4af95d3f0/213b5ee/src/matching/mod.rs:71:1
   |
71 | / lazy_static! {
72 | |     static ref MATCHERS: [Box<Matcher>; 8] = [
73 | |         Box::new(DictionaryMatch {}),
74 | |         Box::new(ReverseDictionaryMatch {}),
...  |
81 | |     ];
82 | | }
   | |_^ `(dyn matching::Matcher + 'static)` cannot be sent between threads safely
   |
   = help: the trait `std::marker::Send` is not implemented for `(dyn matching::Matcher + 'static)`
   = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<(dyn matching::Matcher + 'static)>`
   = note: required because it appears within the type `std::boxed::Box<(dyn matching::Matcher + 'static)>`
   = note: required because it appears within the type `[std::boxed::Box<(dyn matching::Matcher + 'static)>; 8]`
   = note: required because of the requirements on the impl of `std::marker::Sync` for `spin::once::Once<[std::boxed::Box<(dyn matching::Matcher + 'static)>; 8]>`
   = note: required because it appears within the type `lazy_static::lazy::Lazy<[std::boxed::Box<(dyn matching::Matcher + 'static)>; 8]>`
   = note: shared static variables must have a type that implements `Sync`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

I was able to fix it by forking and adding the Send marker trait to Matcher. I'm still new to Rust so if this isn't correct please feel free to disregard this.

