### PR TITLE
Move to 2018 edition, restructure time_estimates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 name = "zxcvbn"
 repository = "https://github.com/shssoichiro/zxcvbn-rs"
 version = "1.0.2"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "shssoichiro/zxcvbn-rs", branch = "master" }

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,8 +1,8 @@
 //! Contains structs and methods related to generating feedback strings
 //! for providing help for the user to generate stronger passwords.
 
-use matching::patterns::*;
-use matching::Match;
+use crate::matching::patterns::*;
+use crate::matching::Match;
 
 /// Verbal feedback to help choose better passwords
 #[derive(Debug, Clone, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,25 +15,24 @@
 
 #[macro_use]
 extern crate derive_builder;
-extern crate fancy_regex;
-extern crate itertools;
+
+
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate quick_error;
-extern crate regex;
+
 #[cfg(feature = "ser")]
 extern crate serde;
 #[cfg(feature = "ser")]
 #[macro_use]
 extern crate serde_derive;
-extern crate time;
+use time;
 
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
-#[cfg(test)]
-extern crate serde_json;
+
 
 pub use crate::matching::Match;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ extern crate quickcheck;
 #[cfg(test)]
 extern crate serde_json;
 
-pub use matching::Match;
+pub use crate::matching::Match;
 
 mod adjacency_graphs;
 pub mod feedback;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 #[macro_use]
 extern crate derive_builder;
 
-
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -32,7 +31,6 @@ use time;
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
-
 
 pub use crate::matching::Match;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,8 @@ pub struct Entropy {
     pub guesses: u64,
     /// Order of magnitude of `guesses`
     pub guesses_log10: f64,
-    /// List of back-of-the-envelope crack time estimations, in seconds, based on a few scenarios
-    pub crack_times_seconds: time_estimates::CrackTimes,
-    /// Same keys as `crack_time_seconds`, with human-readable display values,
-    /// e.g. "less than a second", "3 hours", "centuries", etc.
-    pub crack_times_display: time_estimates::CrackTimesDisplay,
+    /// List of back-of-the-envelope crack time estimations based on a few scenarios.
+    pub crack_times: time_estimates::CrackTimes,
     /// Overall strength score from 0-4.
     /// Any score less than 3 should be considered too weak.
     pub score: u8,
@@ -105,15 +102,13 @@ pub fn zxcvbn(password: &str, user_inputs: &[&str]) -> Result<Entropy, ZxcvbnErr
     let matches = matching::omnimatch(&password, &sanitized_inputs);
     let result = scoring::most_guessable_match_sequence(&password, &matches, false);
     let calc_time = (time::precise_time_ns() - start_time_ns) / 1_000_000;
-    let (attack_times, attack_times_display, score) =
-        time_estimates::estimate_attack_times(result.guesses);
+    let (crack_times, score) = time_estimates::estimate_attack_times(result.guesses);
     let feedback = feedback::get_feedback(score, &matches);
 
     Ok(Entropy {
         guesses: result.guesses,
         guesses_log10: result.guesses_log10,
-        crack_times_seconds: attack_times,
-        crack_times_display: attack_times_display,
+        crack_times,
         score,
         feedback,
         sequence: result.sequence,

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -69,7 +69,7 @@ trait Matcher: Send + Sync {
 }
 
 lazy_static! {
-    static ref MATCHERS: [Box<Matcher>; 8] = [
+    static ref MATCHERS: [Box<dyn Matcher>; 8] = [
         Box::new(DictionaryMatch {}),
         Box::new(ReverseDictionaryMatch {}),
         Box::new(L33tMatch {}),
@@ -877,9 +877,9 @@ lazy_static! {
 
 #[cfg(test)]
 mod tests {
-    use matching;
-    use matching::patterns::*;
-    use matching::Matcher;
+    use crate::matching;
+    use crate::matching::patterns::*;
+    use crate::matching::Matcher;
     use std::collections::HashMap;
     use time;
 

--- a/src/matching/patterns.rs
+++ b/src/matching/patterns.rs
@@ -1,4 +1,4 @@
-use matching::Match;
+use crate::matching::Match;
 use std::collections::HashMap;
 
 /// Pattern type used to detect a match

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,5 +1,5 @@
-use matching::patterns::*;
-use matching::{Match, MatchBuilder};
+use crate::matching::patterns::*;
+use crate::matching::{Match, MatchBuilder};
 use std::cmp;
 use std::collections::HashMap;
 use time;
@@ -42,7 +42,7 @@ const MIN_SUBMATCH_GUESSES_MULTI_CHAR: u64 = 50;
 #[doc(hidden)]
 pub fn most_guessable_match_sequence(
     password: &str,
-    matches: &[::matching::Match],
+    matches: &[crate::matching::Match],
     exclude_additive: bool,
 ) -> GuessCalculation {
     let n = password.chars().count();
@@ -375,11 +375,11 @@ impl Estimator for SpatialPattern {
 }
 
 lazy_static! {
-    static ref KEYBOARD_AVERAGE_DEGREE: usize = calc_average_degree(&::adjacency_graphs::QWERTY);
+    static ref KEYBOARD_AVERAGE_DEGREE: usize = calc_average_degree(&crate::adjacency_graphs::QWERTY);
     // slightly different for keypad/mac keypad, but close enough
-    static ref KEYPAD_AVERAGE_DEGREE: usize = calc_average_degree(&::adjacency_graphs::KEYPAD);
-    static ref KEYBOARD_STARTING_POSITIONS: usize = ::adjacency_graphs::QWERTY.len();
-    static ref KEYPAD_STARTING_POSITIONS: usize = ::adjacency_graphs::KEYPAD.len();
+    static ref KEYPAD_AVERAGE_DEGREE: usize = calc_average_degree(&crate::adjacency_graphs::KEYPAD);
+    static ref KEYBOARD_STARTING_POSITIONS: usize = crate::adjacency_graphs::QWERTY.len();
+    static ref KEYPAD_STARTING_POSITIONS: usize = crate::adjacency_graphs::KEYPAD.len();
 }
 
 fn calc_average_degree(graph: &HashMap<char, Vec<Option<&'static str>>>) -> usize {
@@ -463,11 +463,11 @@ impl Estimator for DatePattern {
 
 #[cfg(test)]
 mod tests {
-    use matching::patterns::*;
-    use matching::MatchBuilder;
+    use crate::matching::patterns::*;
+    use crate::matching::MatchBuilder;
     use quickcheck::TestResult;
-    use scoring;
-    use scoring::Estimator;
+    use crate::scoring;
+    use crate::scoring::Estimator;
     use std::collections::HashMap;
 
     #[test]
@@ -747,7 +747,7 @@ mod tests {
         for &(token, base_token, repeat_count) in &test_data {
             let base_guesses = scoring::most_guessable_match_sequence(
                 base_token,
-                &::matching::omnimatch(base_token, &HashMap::new()),
+                &crate::matching::omnimatch(base_token, &HashMap::new()),
                 false,
             )
             .guesses;

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -465,9 +465,9 @@ impl Estimator for DatePattern {
 mod tests {
     use crate::matching::patterns::*;
     use crate::matching::MatchBuilder;
-    use quickcheck::TestResult;
     use crate::scoring;
     use crate::scoring::Estimator;
+    use quickcheck::TestResult;
     use std::collections::HashMap;
 
     #[test]

--- a/src/time_estimates.rs
+++ b/src/time_estimates.rs
@@ -1,107 +1,136 @@
 //! Contains structs and methods for calculating estimated time
 //! needed to crack a given password.
+//!
+//! # Example
+//! ```rust
+//! # use std::error::Error;
+//! #
+//! # fn main() -> Result<(), Box<dyn Error>> {
+//! use zxcvbn::zxcvbn;
+//! use zxcvbn::time_estimates::CrackTimes;
+//!
+//! let entropy = zxcvbn("password123", &[])?;
+//! assert_eq!(entropy.crack_times.guesses(), 596);
+//! assert_eq!(entropy.crack_times.online_throttling_100_per_hour().to_string(), "5 hours");
+//! assert_eq!(entropy.crack_times.online_no_throttling_10_per_second().to_string(), "59 seconds");
+//! assert_eq!(entropy.crack_times.offline_slow_hashing_1e4_per_second().to_string(), "less than a second");
+//! assert_eq!(entropy.crack_times.offline_fast_hashing_1e10_per_second().to_string(), "less than a second");
+//! #
+//! #     Ok(())
+//! # }
+//! ```
 
-/// Back-of-the-envelope crack time estimations, in seconds, based on a few scenarios
-#[derive(Debug, Clone, Copy)]
+use std::fmt;
+
+/// Back-of-the-envelope crack time estimations, in seconds, based on a few scenarios.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "ser", derive(Serialize))]
 pub struct CrackTimes {
-    /// Online attack on a service that rate-limits password attempts
-    pub online_throttling_100_per_hour: u64,
-    /// Online attack on a service that doesn't rate-limit,
-    /// or where an attacker has outsmarted rate-limiting.
-    pub online_no_throttling_10_per_second: f64,
-    /// Offline attack, assumes multiple attackers.
-    /// Proper user-unique salting, and a slow hash function
-    /// such as bcrypt, scrypt, PBKDF2.
-    pub offline_slow_hashing_1e4_per_second: f64,
-    /// Offline attack with user-unique salting but a fast hash function
-    /// such as SHA-1, SHA-256, or MD5. A wide range of reasonable numbers
-    /// anywhere from one billion to one trillion guesses per second,
-    /// depending on number of cores and machines, ballparking at 10 billion per second.
-    pub offline_fast_hashing_1e10_per_second: f64,
+    guesses: u64,
 }
 
-/// Back-of-the-envelope crack time estimations, in a human-readable format,
-/// based on a few scenarios
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "ser", derive(Serialize))]
-pub struct CrackTimesDisplay {
-    /// Online attack on a service that rate-limits password attempts
-    pub online_throttling_100_per_hour: String,
-    /// Online attack on a service that doesn't rate-limit,
-    /// or where an attacker has outsmarted rate-limiting.
-    pub online_no_throttling_10_per_second: String,
-    /// Offline attack, assumes multiple attackers.
-    /// Proper user-unique salting, and a slow hash function
-    /// such as bcrypt, scrypt, PBKDF2.
-    pub offline_slow_hashing_1e4_per_second: String,
-    /// Offline attack with user-unique salting but a fast hash function
-    /// such as SHA-1, SHA-256, or MD5. A wide range of reasonable numbers
-    /// anywhere from one billion to one trillion guesses per second,
-    /// depending on number of cores and machines, ballparking at 10 billion per second.
-    pub offline_fast_hashing_1e10_per_second: String,
-}
-
-#[doc(hidden)]
-pub fn estimate_attack_times(guesses: u64) -> (CrackTimes, CrackTimesDisplay, u8) {
-    let guesses_f64 = guesses as f64;
-    let crack_times_seconds = CrackTimes {
-        online_throttling_100_per_hour: guesses.saturating_mul(36),
-        online_no_throttling_10_per_second: guesses_f64 / 10.00,
-        offline_slow_hashing_1e4_per_second: guesses_f64 / 10_000.00,
-        offline_fast_hashing_1e10_per_second: guesses_f64 / 10_000_000_000.00,
-    };
-    let crack_times_display = CrackTimesDisplay {
-        online_throttling_100_per_hour: display_time(
-            crack_times_seconds.online_throttling_100_per_hour as u64,
-        ),
-        online_no_throttling_10_per_second: display_time(
-            crack_times_seconds.online_no_throttling_10_per_second as u64,
-        ),
-        offline_slow_hashing_1e4_per_second: display_time(
-            crack_times_seconds.offline_slow_hashing_1e4_per_second as u64,
-        ),
-        offline_fast_hashing_1e10_per_second: display_time(
-            crack_times_seconds.offline_fast_hashing_1e10_per_second as u64,
-        ),
-    };
-    (
-        crack_times_seconds,
-        crack_times_display,
-        calculate_score(guesses),
-    )
-}
-
-fn display_time(seconds: u64) -> String {
-    const MINUTE: u64 = 60;
-    const HOUR: u64 = MINUTE * 60;
-    const DAY: u64 = HOUR * 24;
-    const MONTH: u64 = DAY * 31;
-    const YEAR: u64 = MONTH * 12;
-    const CENTURY: u64 = YEAR * 100;
-    if seconds < 1 {
-        "less than a second".to_string()
-    } else if seconds < MINUTE {
-        let base = seconds;
-        format!("{} second{}", base, if base > 1 { "s" } else { "" })
-    } else if seconds < HOUR {
-        let base = seconds / MINUTE;
-        format!("{} minute{}", base, if base > 1 { "s" } else { "" })
-    } else if seconds < DAY {
-        let base = seconds / HOUR;
-        format!("{} hour{}", base, if base > 1 { "s" } else { "" })
-    } else if seconds < MONTH {
-        let base = seconds / DAY;
-        format!("{} day{}", base, if base > 1 { "s" } else { "" })
-    } else if seconds < YEAR {
-        let base = seconds / MONTH;
-        format!("{} month{}", base, if base > 1 { "s" } else { "" })
-    } else if seconds < CENTURY {
-        let base = seconds / YEAR;
-        format!("{} year{}", base, if base > 1 { "s" } else { "" })
-    } else {
-        "centuries".to_string()
+impl CrackTimes {
+    /// Get the time needed to crack a password based on the amount of guesses needed.
+    ///
+    /// # Arguments
+    /// * `guesses` - The number of guesses needed to crack a password.
+    pub fn new(guesses: u64) -> Self {
+        CrackTimes { guesses }
     }
+
+    /// Get the amount of guesses needed to crack the password.
+    pub fn guesses(&self) -> u64 {
+        self.guesses
+    }
+
+    /// Online attack on a service that rate-limits password attempts.
+    pub fn online_throttling_100_per_hour(&self) -> CrackTimeSeconds {
+        CrackTimeSeconds::Integer(self.guesses.saturating_mul(36))
+    }
+
+    /// Online attack on a service that doesn't rate-limit,
+    /// or where an attacker has outsmarted rate-limiting.
+    pub fn online_no_throttling_10_per_second(&self) -> CrackTimeSeconds {
+        CrackTimeSeconds::Float(self.guesses as f64 / 10.00)
+    }
+
+    /// Offline attack, assumes multiple attackers.
+    /// Proper user-unique salting, and a slow hash function
+    /// such as bcrypt, scrypt, PBKDF2.
+    pub fn offline_slow_hashing_1e4_per_second(&self) -> CrackTimeSeconds {
+        CrackTimeSeconds::Float(self.guesses as f64 / 10_000.00)
+    }
+
+    /// Offline attack with user-unique salting but a fast hash function
+    /// such as SHA-1, SHA-256, or MD5. A wide range of reasonable numbers
+    /// anywhere from one billion to one trillion guesses per second,
+    /// depending on number of cores and machines, ballparking at 10 billion per second.
+    pub fn offline_fast_hashing_1e10_per_second(&self) -> CrackTimeSeconds {
+        CrackTimeSeconds::Float(self.guesses as f64 / 10_000_000_000.00)
+    }
+}
+
+/// Represents the time to crack a password.
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "ser", derive(Serialize))]
+#[cfg_attr(feature = "ser", serde(untagged))]
+pub enum CrackTimeSeconds {
+    /// The number of seconds needed to crack a password, expressed as an integer.
+    Integer(u64),
+    /// The number of seconds needed to crack a password, expressed as a float.
+    Float(f64),
+}
+
+impl fmt::Display for CrackTimeSeconds {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let seconds = match self {
+            CrackTimeSeconds::Integer(i) => *i,
+            CrackTimeSeconds::Float(f) => *f as u64,
+        };
+        const MINUTE: u64 = 60;
+        const HOUR: u64 = MINUTE * 60;
+        const DAY: u64 = HOUR * 24;
+        const MONTH: u64 = DAY * 31;
+        const YEAR: u64 = MONTH * 12;
+        const CENTURY: u64 = YEAR * 100;
+        if seconds < 1 {
+            write!(f, "less than a second")
+        } else if seconds < MINUTE {
+            let base = seconds;
+            write!(f, "{} second{}", base, if base > 1 { "s" } else { "" })
+        } else if seconds < HOUR {
+            let base = seconds / MINUTE;
+            write!(f, "{} minute{}", base, if base > 1 { "s" } else { "" })
+        } else if seconds < DAY {
+            let base = seconds / HOUR;
+            write!(f, "{} hour{}", base, if base > 1 { "s" } else { "" })
+        } else if seconds < MONTH {
+            let base = seconds / DAY;
+            write!(f, "{} day{}", base, if base > 1 { "s" } else { "" })
+        } else if seconds < YEAR {
+            let base = seconds / MONTH;
+            write!(f, "{} month{}", base, if base > 1 { "s" } else { "" })
+        } else if seconds < CENTURY {
+            let base = seconds / YEAR;
+            write!(f, "{} year{}", base, if base > 1 { "s" } else { "" })
+        } else {
+            write!(f, "centuries")
+        }
+    }
+}
+
+impl From<CrackTimeSeconds> for std::time::Duration {
+    fn from(s: CrackTimeSeconds) -> std::time::Duration {
+        match s {
+            // TODO: Use `from_secs_f64` when it is stable
+            CrackTimeSeconds::Float(f) => std::time::Duration::from_secs(f as u64),
+            CrackTimeSeconds::Integer(i) => std::time::Duration::from_secs(i),
+        }
+    }
+}
+
+pub(crate) fn estimate_attack_times(guesses: u64) -> (CrackTimes, u8) {
+    (CrackTimes::new(guesses), calculate_score(guesses))
 }
 
 fn calculate_score(guesses: u64) -> u8 {


### PR DESCRIPTION
- Moves the repository to the 2018 editions and applies the edition idioms.
- Restructures `time_estimates`: the properties of `CrackTimes` are now methods that return a `CrackTimeSeconds`, which implements `Display`. This means allocations are not needed by default.