### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -993,7 +993,7 @@ mod tests {
     fn test_dictionary_matches_user_inputs() {
         use crate::frequency_lists::DictionaryType;
         let user_inputs = [("bejeebus".to_string(), 1)]
-            .into_iter()
+            .iter()
             .cloned()
             .collect::<HashMap<String, usize>>();
         let matches = (matching::DictionaryMatch {}).get_matches("bejeebus", &user_inputs);


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.