### PR TITLE
Fix repeat detection with multibyte chars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 derive_builder = "0.8.0"
-fancy-regex = "0.2.0"
+fancy-regex = "0.3.0"
 itertools = "0.8.0"
 lazy_static = "1.3"
 quick-error = "1.2"

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -457,9 +457,11 @@ impl Matcher for RepeatMatch {
                 m4tch = lazy_matches;
                 m4tch.get(1).unwrap().as_str().to_string()
             };
+
+            let m = m4tch.get(0).unwrap();
             let (i, j) = (
-                m4tch.get(0).unwrap().start() + last_index,
-                m4tch.get(0).unwrap().end() + last_index - 1,
+                last_index + token[..m.start()].chars().count(),
+                last_index + token[..m.end()].chars().count() - 1,
             );
             // recursively match and score the base string
             let base_analysis = super::scoring::most_guessable_match_sequence(
@@ -1424,7 +1426,7 @@ mod tests {
     #[test]
     fn test_identifies_repeat_with_multibyte_utf8() {
         let password = "x\u{1F431}\u{1F436}\u{1F431}\u{1F436}";
-        let (i, j) = (1, 16);
+        let (i, j) = (1, 4);
         let matches = (matching::RepeatMatch {}).get_matches(password, &HashMap::new());
         let m = matches.iter().find(|m| m.token == password[1..]).unwrap();
         assert_eq!(m.i, i);


### PR DESCRIPTION
fancy-regex 0.3.0 includes this fix: https://github.com/fancy-regex/fancy-regex/pull/36

Note that the build for this will fail, because removing the `if` uncovers a problem on this line:

```
m4tch.get(0).unwrap().end() + last_index - 1,
```

There's two different things being summed here:

* The `last_index` is a *character* index (not sure why, looks like `i` and `j` are both character indexes?)
* `end()` returns a *byte* index, which is normal for str APIs in Rust

So this won't work unless the string is ASCII.