### PR TITLE
Improve performance

### DIFF
--- a/src/matching/char_indexing.rs
+++ b/src/matching/char_indexing.rs
@@ -9,6 +9,12 @@ pub struct CharIndexableStr<'a> {
     indices: Vec<usize>,
 }
 
+impl CharIndexableStr<'_> {
+    pub(crate) fn char_count(&self) -> usize {
+        self.indices.len()
+    }
+}
+
 impl<'a> From<&'a str> for CharIndexableStr<'a> {
     fn from(s: &'a str) -> Self {
         CharIndexableStr {

--- a/src/matching/char_indexing.rs
+++ b/src/matching/char_indexing.rs
@@ -1,0 +1,29 @@
+use std::ops::Range;
+
+pub(crate) trait CharIndexable<'b> {
+    fn char_index(&'b self, range: Range<usize>) -> &'b str;
+}
+
+pub struct CharIndexableStr<'a> {
+    s: &'a str,
+    indices: Vec<usize>,
+}
+
+impl<'a> From<&'a str> for CharIndexableStr<'a> {
+    fn from(s: &'a str) -> Self {
+        CharIndexableStr {
+            indices: s.char_indices().map(|(i, _c)| i).collect(),
+            s,
+        }
+    }
+}
+
+impl<'a, 'b: 'a> CharIndexable<'b> for CharIndexableStr<'a> {
+    fn char_index(&'b self, range: Range<usize>) -> &'b str {
+        if range.end >= self.indices.len() {
+            &self.s[self.indices[range.start]..]
+        } else {
+            &self.s[self.indices[range.start]..self.indices[range.end]]
+        }
+    }
+}


### PR DESCRIPTION
By caching the char indices and indexing the string with them, some allocations can be prevented. This improves performance significantly:
```
zxcvbn                  time:   [617.36 us 620.74 us 624.93 us]
                        change: [-63.875% -63.162% -62.579%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

zxcvbn_unicode          time:   [14.585 us 14.648 us 14.726 us]
                        change: [-53.451% -53.179% -52.916%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```

**This commit does change the public interface of two patterns.**
