### PR TITLE
Adds wasm32 support (using wasm-bindgen)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.8.0"
 lazy_static = "1.3"
 quick-error = "1.2"
 regex = "1"
-chrono = "0.4.7"
+chrono = { version = "0.4.7", features = ["wasmbind"] }
 
 [dependencies.serde]
 optional = true
@@ -34,6 +34,9 @@ version = "1"
 quickcheck = "0.9.0"
 serde_json = "1"
 criterion = "0.3"
+
+[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ quickcheck = "0.9.0"
 serde_json = "1"
 criterion = "0.3"
 
-[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ extern crate serde;
 #[cfg(feature = "ser")]
 #[macro_use]
 extern crate serde_derive;
-use std::time::{Duration, Instant};
+use chrono::Utc;
+use std::time::Duration;
 
 #[cfg(test)]
 #[macro_use]
@@ -110,6 +111,10 @@ quick_error! {
         BlankPassword {
             description("Zxcvbn cannot evaluate a blank password")
         }
+        /// Indicates an error converting Duration to/from the standard library implementation
+        DurationOutOfRange {
+            description("Zxcvbn calculation time created a duration out of range")
+        }
     }
 }
 
@@ -126,7 +131,7 @@ pub fn zxcvbn(password: &str, user_inputs: &[&str]) -> Result<Entropy, ZxcvbnErr
         return Err(ZxcvbnError::BlankPassword);
     }
 
-    let start_time = Instant::now();
+    let start_time = Utc::now();
 
     // Only evaluate the first 100 characters of the input.
     // This prevents potential DoS attacks from sending extremely long input strings.
@@ -140,7 +145,9 @@ pub fn zxcvbn(password: &str, user_inputs: &[&str]) -> Result<Entropy, ZxcvbnErr
 
     let matches = matching::omnimatch(&password, &sanitized_inputs);
     let result = scoring::most_guessable_match_sequence(&password, &matches, false);
-    let calc_time = Instant::now() - start_time;
+    let calc_time = (Utc::now() - start_time)
+        .to_std()
+        .map_err(|_| ZxcvbnError::DurationOutOfRange)?;
     let (crack_times, score) = time_estimates::estimate_attack_times(result.guesses);
     let feedback = feedback::get_feedback(score, &matches);
 
@@ -160,6 +167,12 @@ mod tests {
     use super::*;
     use quickcheck::TestResult;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
     quickcheck! {
         fn test_zxcvbn_doesnt_panic(password: String, user_inputs: Vec<String>) -> TestResult {
             let inputs = user_inputs.iter().map(|s| s.as_ref()).collect::<Vec<&str>>();
@@ -175,7 +188,8 @@ mod tests {
         }
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_zxcvbn() {
         let password = "r0sebudmaelstrom11/20/91aaaa";
         let entropy = zxcvbn(password, &[]).unwrap();
@@ -185,28 +199,32 @@ mod tests {
         assert!(entropy.feedback.is_none());
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_zxcvbn_unicode() {
         let password = "𐰊𐰂𐰄𐰀𐰁";
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.score, 1);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_zxcvbn_unicode_2() {
         let password = "r0sebudmaelstrom丂/20/91aaaa";
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.score, 4);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_issue_13() {
         let password = "Imaginative-Say-Shoulder-Dish-0";
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.score, 4);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_issue_15_example_1() {
         let password = "TestMeNow!";
         let entropy = zxcvbn(password, &[]).unwrap();
@@ -215,7 +233,8 @@ mod tests {
         assert_eq!(entropy.score, 3);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_issue_15_example_2() {
         let password = "hey<123";
         let entropy = zxcvbn(password, &[]).unwrap();
@@ -224,7 +243,8 @@ mod tests {
         assert_eq!(entropy.score, 2);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_overflow_safety() {
         let password = "!QASW@#EDFR$%TGHY^&UJKI*(OL";
         let entropy = zxcvbn(password, &[]).unwrap();
@@ -232,7 +252,8 @@ mod tests {
         assert_eq!(entropy.score, 4);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_unicode_mb() {
         let password = "08märz2010";
         let entropy = zxcvbn(password, &[]).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ quick_error! {
         }
         /// Indicates an error converting Duration to/from the standard library implementation
         DurationOutOfRange {
-            description("Zxcvbn calculation time created a duration out of range")
+            display("Zxcvbn calculation time created a duration out of range")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,10 +168,7 @@ mod tests {
     use quickcheck::TestResult;
 
     #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
-
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test_configure!(run_in_browser);
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     quickcheck! {
         fn test_zxcvbn_doesnt_panic(password: String, user_inputs: Vec<String>) -> TestResult {
@@ -197,6 +194,7 @@ mod tests {
         assert_eq!(entropy.score, 4);
         assert!(!entropy.sequence.is_empty());
         assert!(entropy.feedback.is_none());
+        assert!(entropy.calc_time.as_nanos() > 0);
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -374,19 +374,19 @@ impl Estimator for SpatialPattern {
 }
 
 lazy_static! {
-    static ref KEYBOARD_AVERAGE_DEGREE: usize = calc_average_degree(&crate::adjacency_graphs::QWERTY);
+    static ref KEYBOARD_AVERAGE_DEGREE: u64 = calc_average_degree(&crate::adjacency_graphs::QWERTY);
     // slightly different for keypad/mac keypad, but close enough
-    static ref KEYPAD_AVERAGE_DEGREE: usize = calc_average_degree(&crate::adjacency_graphs::KEYPAD);
-    static ref KEYBOARD_STARTING_POSITIONS: usize = crate::adjacency_graphs::QWERTY.len();
-    static ref KEYPAD_STARTING_POSITIONS: usize = crate::adjacency_graphs::KEYPAD.len();
+    static ref KEYPAD_AVERAGE_DEGREE: u64 = calc_average_degree(&crate::adjacency_graphs::KEYPAD);
+    static ref KEYBOARD_STARTING_POSITIONS: u64 = crate::adjacency_graphs::QWERTY.len() as u64;
+    static ref KEYPAD_STARTING_POSITIONS: u64 = crate::adjacency_graphs::KEYPAD.len() as u64;
 }
 
-fn calc_average_degree(graph: &HashMap<char, Vec<Option<&'static str>>>) -> usize {
-    let sum: usize = graph
+fn calc_average_degree(graph: &HashMap<char, Vec<Option<&'static str>>>) -> u64 {
+    let sum: u64 = graph
         .values()
-        .map(|neighbors| neighbors.iter().filter(|n| n.is_some()).count())
+        .map(|neighbors| neighbors.iter().filter(|n| n.is_some()).count() as u64)
         .sum();
-    sum / graph.len()
+    sum / graph.len() as u64
 }
 
 impl Estimator for RepeatPattern {
@@ -867,7 +867,7 @@ mod tests {
         let token = "zxcvbn";
         let base_guesses = *scoring::KEYBOARD_STARTING_POSITIONS
             * *scoring::KEYBOARD_AVERAGE_DEGREE
-            * (token.len() - 1);
+            * (token.len() - 1) as u64;
         assert_eq!(p.estimate(token), base_guesses as u64);
     }
 
@@ -881,9 +881,9 @@ mod tests {
             .build()
             .unwrap();
         let token = "ZxCvbn";
-        let base_guesses = (*scoring::KEYBOARD_STARTING_POSITIONS
+        let base_guesses = *scoring::KEYBOARD_STARTING_POSITIONS
             * *scoring::KEYBOARD_AVERAGE_DEGREE
-            * (token.len() - 1)) as u64
+            * (token.len() - 1) as u64
             * (scoring::n_ck(6, 2) + scoring::n_ck(6, 1));
         assert_eq!(p.estimate(token), base_guesses);
     }
@@ -900,7 +900,7 @@ mod tests {
         let token = "ZXCVBN";
         let base_guesses = *scoring::KEYBOARD_STARTING_POSITIONS
             * *scoring::KEYBOARD_AVERAGE_DEGREE
-            * (token.len() - 1)
+            * (token.len() - 1) as u64
             * 2;
         assert_eq!(p.estimate(token), base_guesses as u64);
     }


### PR DESCRIPTION
We've added wasm32 support by eliminating the std::time::Instant usage and adding the `wasmbind` chrono feature since it was already a dependency.

Instead of using usize types in scoring which failed the overflow test on wasm32 we switched to consistently using u64 types. Wasm-bindgen allows for u64 types by translating to the BigInt type in JS.

All integration tests are passing when running `wasm-pack test --node` 