### PR TITLE
Make use of builder pattern optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "shssoichiro/zxcvbn-rs", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-derive_builder = "0.9.0"
+derive_builder = { version = "0.9.0", optional = true }
 fancy-regex = "0.3.0"
 itertools = "0.9.0"
 lazy_static = "1.3"
@@ -36,8 +36,9 @@ serde_json = "1"
 criterion = "0.3"
 
 [features]
-default = []
+default = ["builder"]
 ser = ["serde", "serde_derive"]
+builder = ["derive_builder"]
 
 [profile.test]
 opt-level = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 #![forbid(unsafe_code)]
 
 #[macro_use]
+#[cfg(feature = "builder")]
 extern crate derive_builder;
 
 #[macro_use]

--- a/src/matching/patterns.rs
+++ b/src/matching/patterns.rs
@@ -46,8 +46,9 @@ impl Default for MatchPattern {
 }
 
 /// A match based on a word in a dictionary
-#[derive(Debug, Clone, PartialEq, Default, Builder)]
-#[builder(default)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[cfg_attr(feature = "builder", builder(default))]
 #[cfg_attr(feature = "ser", derive(Serialize))]
 pub struct DictionaryPattern {
     /// Word that has been found in a dictionary.
@@ -73,8 +74,9 @@ pub struct DictionaryPattern {
 }
 
 /// A match based on keys being close to one another on the keyboard
-#[derive(Debug, Clone, PartialEq, Default, Builder)]
-#[builder(default)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[cfg_attr(feature = "builder", builder(default))]
 #[cfg_attr(feature = "ser", derive(Serialize))]
 pub struct SpatialPattern {
     /// Name of the graph for which a spatial match has been found.
@@ -86,8 +88,9 @@ pub struct SpatialPattern {
 }
 
 /// A match based on repeating patterns
-#[derive(Debug, Clone, PartialEq, Default, Builder)]
-#[builder(default)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[cfg_attr(feature = "builder", builder(default))]
 #[cfg_attr(feature = "ser", derive(Serialize))]
 pub struct RepeatPattern {
     /// Base token that repeats in the matched pattern.
@@ -101,8 +104,9 @@ pub struct RepeatPattern {
 }
 
 /// A match based on sequences of characters, e.g. "abcd"
-#[derive(Debug, Clone, PartialEq, Default, Builder)]
-#[builder(default)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[cfg_attr(feature = "builder", builder(default))]
 #[cfg_attr(feature = "ser", derive(Serialize))]
 pub struct SequencePattern {
     /// Name of the sequence that was matched.
@@ -114,8 +118,9 @@ pub struct SequencePattern {
 }
 
 /// A match based on one of the regex patterns used in zxcvbn.
-#[derive(Debug, Clone, PartialEq, Default, Builder)]
-#[builder(default)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[cfg_attr(feature = "builder", builder(default))]
 #[cfg_attr(feature = "ser", derive(Serialize))]
 pub struct RegexPattern {
     /// Name of the regular expression that was matched.
@@ -125,8 +130,9 @@ pub struct RegexPattern {
 }
 
 /// A match based on date patterns
-#[derive(Debug, Clone, PartialEq, Default, Builder)]
-#[builder(default)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[cfg_attr(feature = "builder", builder(default))]
 #[cfg_attr(feature = "ser", derive(Serialize))]
 pub struct DatePattern {
     /// Separator of a date that was matched.


### PR DESCRIPTION
Now the builder patterns are only generated if the "builder" feature is enabled
(which is the default). Disabling it avoids some heavy dependencies for implementing the procedural macros, which can save a lot of compile time.

This is technically a breaking change for anyone who builds zxcvbn with
`no-default-features = true` and uses the builder patterns. (This should not be
the case often, because the zxcvbn did not have default features before.)

Refs #35.