### PR TITLE
Fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ use zxcvbn::zxcvbn;
 
 fn main() {
     let estimate = zxcvbn("correcthorsebatterystaple", &[]).unwrap();
-    println!("{}", estimate.score); // 3
+    println!("{}", estimate.score()); // 3
 }
 ```
 


### PR DESCRIPTION
This fixes the usage example in the README.

Previously:

```
error[E0616]: field `score` of struct `Entropy` is private
 --> src/main.rs:7:29
  |
7 |     println!("{}", estimate.score); // 3
  |                             ^^^^^ private field
  |
help: a method `score` also exists, call it with parentheses
  |
7 |     println!("{}", estimate.score()); // 3
  |                                  ^^

error: aborting due to previous error
```