### PR TITLE
Don't depend on chrono oldtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.10.0"
 lazy_static = "1.3"
 quick-error = "2.0"
 regex = "1"
-chrono = "0.4.7"
+chrono = { version = "0.4.7", default-features = false, features = ["clock", "std"] }
 
 [dependencies.serde]
 optional = true


### PR DESCRIPTION
We don't need the time::Duration type, so we can get rid of the
(deprecated) time 0.1 dependency by disabling the oldtime chrono
feature