### PR TITLE
Include README.md as doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 ## Overview
 
-This library is a Rust port of Dropbox's `zxcvbn` Javascript library. The following description is borrowed from their Readme:
-
-`zxcvbn` is a password strength estimator inspired by password crackers. Through pattern matching and conservative estimation, it recognizes and weighs 30k common passwords, common names and surnames according to US census data, popular English words from Wikipedia and US television and movies, and other common patterns like dates, repeats (`aaa`), sequences (`abcd`), keyboard patterns (`qwertyuiop`), and l33t speak.
+`zxcvbn` is a password strength estimator based off of Dropbox's zxcvbn library. Through pattern matching and conservative estimation, it recognizes and weighs 30k common passwords, common names and surnames according to US census data, popular English words from Wikipedia and US television and movies, and other common patterns like dates, repeats (`aaa`), sequences (`abcd`), keyboard patterns (`qwertyuiop`), and l33t speak.
 
 Consider using zxcvbn as an algorithmic alternative to password composition policy — it is more secure, flexible, and usable when sites require a minimal complexity score in place of annoying rules like "passwords must contain three of {lower, upper, numbers, symbols}".
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,4 @@
-//! `zxcvbn` is a password strength estimator based off of Dropbox's zxcvbn library.
-//!
-//! Through pattern matching and conservative estimation, it recognizes and weighs
-//! 30k common passwords, common names and surnames according to US census data,
-//! popular English words from Wikipedia and US television and movies, and other
-//! common patterns like dates, repeats (aaa), sequences (abcd),
-//! keyboard patterns (qwertyuiop), and l33t speak.
-//!
-//! Consider using zxcvbn as an algorithmic alternative to password composition policy —
-//! it is more secure, flexible, and usable when sites require
-//! a minimal complexity score in place of annoying rules like
-//! "passwords must contain three of {lower, upper, numbers, symbols}".
+#![doc = include_str!("../README.md")]
 #![recursion_limit = "128"]
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Instead of having the top-most documentation different from the Readme, simply import it. This also runs the Readme code as a doc test.