### PR TITLE
Change feedback to return Option<&Feedback>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,8 @@ impl Entropy {
     }
 
     /// Feedback to help choose better passwords. Set when `score` <= 2.
-    pub fn feedback(&self) -> &Option<feedback::Feedback> {
-        &self.feedback
+    pub fn feedback(&self) -> Option<&feedback::Feedback> {
+        self.feedback.as_ref()
     }
 
     /// The list of patterns the guess calculation was based on


### PR DESCRIPTION
This PR changes the `Entropy::feedback()` function to return `Option<&Feedback>` instead of `&Option<Feedback>`. This makes the API significantly easier to use as `Option<&...>` implements `Copy` and it's also more accurate, semantically.

Say I want to call map on the return value of the function:

```rust
let feedback = entropy.feedback().map(|f| f.to_owned());
```

This results in an error with `&Option<Feedback>`:

```
error[E0507]: cannot move out of a shared reference
    --> ui/src/routes/auth.rs:233:38
     |
233  |                         feedback.set(entropy.feedback().map(|f| f.to_owned()));
     |                                      ^^^^^^^^^^^^^^^^^^ --------------------- value moved due to this method call
     |                                      |
     |                                      help: consider calling `.as_ref()` or `.as_mut()` to borrow the type's contents
     |                                      move occurs because value has type `std::option::Option<Feedback>`, which does not implement the `Copy` trait
     |
note: `std::option::Option::<T>::map` takes ownership of the receiver `self`, which moves value
```

Using `Option<&Feedback>` makes this compile without any errors.