### PR TITLE
Use minimal regex/fancy-regex build features to reduce build size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,20 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 derive_builder = { version = "0.12.0", optional = true }
-fancy-regex = "0.11.0"
 itertools = "0.10.0"
 lazy_static = "1.3"
 quick-error = "2.0"
-regex = "1"
 time = { version = "0.3" }
+
+[dependencies.regex]
+version = "1"
+default-features = false
+features = ["std"]
+
+[dependencies.fancy-regex]
+version = "0.13.0"
+default-features = false
+features = ["std"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.56"

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -848,7 +848,7 @@ lazy_static! {
         table
     };
     static ref MAYBE_DATE_NO_SEPARATOR_REGEX: Regex = Regex::new(r"^[0-9]{4,8}$").unwrap();
-    static ref MAYBE_DATE_WITH_SEPARATOR_REGEX: Regex = Regex::new(r"^([0-9]{1,4})([\s/\\_.-])([0-9]{1,2})([\s/\\_.-])([0-9]{1,4})$").unwrap();
+    static ref MAYBE_DATE_WITH_SEPARATOR_REGEX: Regex = Regex::new(r"^([0-9]{1,4})([ \t\r\n/\\_.-])([0-9]{1,2})([[ \t\r\n/\\_.-]/\\_.-])([0-9]{1,4})$").unwrap();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When building a WASM module that uses zxcvbn-rs, I found I was able to reduce the build size by roughly 25% by setting the regex and fancy-regex package features to use only standard library support, and avoid using unicode character classes such as `\s`.

This PR replaces `\s` with `  \t\r\n` in `MAYBE_DATE_WITH_SEPARATOR_REGEX`, and sets `features = ["std"]` on the regex and fancy-regex dependencies.

See here for more info on this optimization for the regex dependency:  https://github.com/rust-lang/regex?tab=readme-ov-file#crate-features.