### PR TITLE
refactored score to type Score enum, for failure proof matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ use zxcvbn::zxcvbn;
 
 fn main() {
     let estimate = zxcvbn("correcthorsebatterystaple", &[]).unwrap();
-    println!("{}", estimate.score()); // 3
+    println!("{:?}", estimate.score()); // 3
 }
 ```
 

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -4,6 +4,7 @@
 use crate::frequency_lists::DictionaryType;
 use crate::matching::patterns::*;
 use crate::matching::Match;
+use crate::Score;
 use std::fmt;
 
 /// A warning explains what's wrong with the password.
@@ -153,7 +154,7 @@ impl Feedback {
     }
 }
 
-pub(crate) fn get_feedback(score: u8, sequence: &[Match]) -> Option<Feedback> {
+pub(crate) fn get_feedback(score: Score, sequence: &[Match]) -> Option<Feedback> {
     if sequence.is_empty() {
         // default feedback
         return Some(Feedback {
@@ -164,7 +165,7 @@ pub(crate) fn get_feedback(score: u8, sequence: &[Match]) -> Option<Feedback> {
             ],
         });
     }
-    if score >= 3 {
+    if score == Score::Medium || score == Score::Perfect {
         return None;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,21 @@ pub mod matching;
 mod scoring;
 pub mod time_estimates;
 
+/// score type: Variants are self explanatory
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum Score {
+    /// SuperWeak: too lazy! 🙄
+    SuperWeak,
+    /// VeryWeak: a useless password ❌
+    VeryWeak,
+    /// Weak: easily crackable 👎
+    Weak,
+    /// Medium: need a bit more effort 😩
+    Medium,
+    /// Perfect: just enough, for now :)💪
+    Perfect,
+}
+
 /// Contains the results of an entropy calculation
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "ser", derive(Serialize))]
@@ -45,7 +60,7 @@ pub struct Entropy {
     crack_times: time_estimates::CrackTimes,
     /// Overall strength score from 0-4.
     /// Any score less than 3 should be considered too weak.
-    score: u8,
+    score: Score,
     /// Verbal feedback to help choose better passwords. Set when `score` <= 2.
     feedback: Option<feedback::Feedback>,
     /// The list of patterns the guess calculation was based on
@@ -72,7 +87,7 @@ impl Entropy {
 
     /// Overall strength score from 0-4.
     /// Any score less than 3 should be considered too weak.
-    pub fn score(&self) -> u8 {
+    pub fn score(&self) -> Score {
         self.score
     }
 
@@ -188,7 +203,7 @@ mod tests {
         let password = "r0sebudmaelstrom11/20/91aaaa";
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.guesses_log10 as u16, 14);
-        assert_eq!(entropy.score, 4);
+        assert_eq!(entropy.score, Score::Perfect);
         assert!(!entropy.sequence.is_empty());
         assert!(entropy.feedback.is_none());
         assert!(entropy.calc_time.as_nanos() > 0);
@@ -199,7 +214,7 @@ mod tests {
     fn test_zxcvbn_unicode() {
         let password = "𐰊𐰂𐰄𐰀𐰁";
         let entropy = zxcvbn(password, &[]).unwrap();
-        assert_eq!(entropy.score, 1);
+        assert_eq!(entropy.score, Score::VeryWeak);
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -207,7 +222,7 @@ mod tests {
     fn test_zxcvbn_unicode_2() {
         let password = "r0sebudmaelstrom丂/20/91aaaa";
         let entropy = zxcvbn(password, &[]).unwrap();
-        assert_eq!(entropy.score, 4);
+        assert_eq!(entropy.score, Score::Perfect);
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -215,7 +230,7 @@ mod tests {
     fn test_issue_13() {
         let password = "Imaginative-Say-Shoulder-Dish-0";
         let entropy = zxcvbn(password, &[]).unwrap();
-        assert_eq!(entropy.score, 4);
+        assert_eq!(entropy.score, Score::Perfect);
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -225,7 +240,7 @@ mod tests {
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.guesses, 372_010_000);
         assert!((entropy.guesses_log10 - 8.57055461430783).abs() < f64::EPSILON);
-        assert_eq!(entropy.score, 3);
+        assert_eq!(entropy.score, Score::Medium);
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -235,7 +250,7 @@ mod tests {
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.guesses, 1_010_000);
         assert!((entropy.guesses_log10 - 6.004321373782642).abs() < f64::EPSILON);
-        assert_eq!(entropy.score, 2);
+        assert_eq!(entropy.score, Score::Weak);
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -244,7 +259,7 @@ mod tests {
         let password = "!QASW@#EDFR$%TGHY^&UJKI*(OL";
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.guesses, u64::max_value());
-        assert_eq!(entropy.score, 4);
+        assert_eq!(entropy.score, Score::Perfect);
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -253,6 +268,6 @@ mod tests {
         let password = "08märz2010";
         let entropy = zxcvbn(password, &[]).unwrap();
         assert_eq!(entropy.guesses, 100010000);
-        assert_eq!(entropy.score, 3);
+        assert_eq!(entropy.score, Score::Medium);
     }
 }

--- a/src/time_estimates.rs
+++ b/src/time_estimates.rs
@@ -20,6 +20,7 @@
 //! # }
 //! ```
 
+use crate::Score;
 use std::fmt;
 
 /// Back-of-the-envelope crack time estimations, in seconds, based on a few scenarios.
@@ -129,21 +130,21 @@ impl From<CrackTimeSeconds> for std::time::Duration {
     }
 }
 
-pub(crate) fn estimate_attack_times(guesses: u64) -> (CrackTimes, u8) {
+pub(crate) fn estimate_attack_times(guesses: u64) -> (CrackTimes, Score) {
     (CrackTimes::new(guesses), calculate_score(guesses))
 }
 
-fn calculate_score(guesses: u64) -> u8 {
+fn calculate_score(guesses: u64) -> Score {
     const DELTA: u64 = 5;
     if guesses < 1_000 + DELTA {
-        0
+        Score::SuperWeak // previously, 0
     } else if guesses < 1_000_000 + DELTA {
-        1
+        Score::VeryWeak // peviously, 1
     } else if guesses < 100_000_000 + DELTA {
-        2
+        Score::Weak // previously, 2
     } else if guesses < 10_000_000_000 + DELTA {
-        3
+        Score::Medium // previously, 3
     } else {
-        4
+        Score::Perfect // previously, 4
     }
 }


### PR DESCRIPTION
Currently, Entropy.score is a u8. This is problematic as foolproof matching is less than ideal in downstream code. The API doesn't make it clear that there are really only 5 variants from 0 to 4. One has to account for u8s higher than 4. Converting to the Score Enum just makes this clear and safer. This might be a backward incompatible change, but better to do this now than later. 