### PR TITLE
Add support for WASM targets running in a custom runtime

### DIFF
--- a/.github/workflows/zxcvbn.yml
+++ b/.github/workflows/zxcvbn.yml
@@ -96,4 +96,6 @@ jobs:
         run: cargo build --target wasm32-unknown-unknown --tests --benches
 
       - name: Run tests (wasm, all features)
-        run: wasm-pack test --node --all-features
+        env:
+          ALL_WASM_BINDGEN_FEATURES: "default,ser,builder"
+        run: wasm-pack test --node --features $ALL_WASM_BINDGEN_FEATURES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 criterion = { version = "0.5", default-features = false }
+getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ itertools = "0.13"
 lazy_static = "1.3"
 regex = "1"
 time = { version = "0.3" }
+chrono = "0.4"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+[target.'cfg(all(target_arch = "wasm32", not(feature = "non-js")))'.dependencies]
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Performance"] }
 
@@ -39,7 +39,7 @@ serde_json = "1"
 criterion = "0.5"
 serde_json = "1"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(feature = "non-js")))'.dev-dependencies]
 criterion = { version = "0.5", default-features = false }
 wasm-bindgen-test = "0.3"
 
@@ -47,6 +47,7 @@ wasm-bindgen-test = "0.3"
 default = ["builder"]
 ser = ["serde"]
 builder = ["derive_builder"]
+non-js = []
 
 [profile.test]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ itertools = "0.13"
 lazy_static = "1.3"
 regex = "1"
 time = { version = "0.3" }
-chrono = "0.4"
 
-[target.'cfg(all(target_arch = "wasm32", not(feature = "non-js")))'.dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+chrono = "0.4.38"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Performance"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1"
 criterion = "0.5"
 serde_json = "1"
 
-[target.'cfg(all(target_arch = "wasm32", not(feature = "non-js")))'.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 criterion = { version = "0.5", default-features = false }
 wasm-bindgen-test = "0.3"
 
@@ -47,7 +47,7 @@ wasm-bindgen-test = "0.3"
 default = ["builder"]
 ser = ["serde"]
 builder = ["derive_builder"]
-non-js = []
+custom_wasm_env = []
 
 [profile.test]
 opt-level = 2

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -292,7 +292,7 @@ fn get_dictionary_match_feedback(
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", not(feature = "non-js")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -292,7 +292,7 @@ fn get_dictionary_match_feedback(
 mod tests {
     use super::*;
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "custom_wasm_env")))]
+    #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -292,7 +292,7 @@ fn get_dictionary_match_feedback(
 mod tests {
     use super::*;
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "non-js")))]
+    #[cfg(all(target_arch = "wasm32", not(feature = "custom_wasm_env")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ extern crate quickcheck;
 
 pub use scoring::Score;
 use time_estimates::CrackTimes;
-#[cfg(all(target_arch = "wasm32", not(feature = "non-js")))]
+#[cfg(all(target_arch = "wasm32", not(feature = "custom_wasm_env")))]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 pub use crate::matching::Match;
@@ -41,7 +41,7 @@ where
     (result, calc_time)
 }
 
-#[cfg(all(target_arch = "wasm32", not(feature = "non-js")))]
+#[cfg(all(target_arch = "wasm32", not(feature = "custom_wasm_env")))]
 #[allow(non_upper_case_globals)]
 fn time_scoped<F, R>(f: F) -> (R, Duration)
 where
@@ -60,7 +60,7 @@ where
     (result, calc_time)
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "non-js"))]
+#[cfg(all(target_arch = "wasm32", feature = "custom_wasm_env"))]
 fn time_scoped<F, R>(f: F) -> (R, Duration)
 where
     F: FnOnce() -> R,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,13 +69,9 @@ where
     extern "C" {
         fn unix_time_milliseconds_imported() -> u64;
     }
-    let start_time = unsafe { 
-        unix_time_milliseconds_imported()
-    };
+    let start_time = unsafe { unix_time_milliseconds_imported() };
     let result = f();
-    let end_time = unsafe { 
-        unix_time_milliseconds_imported()
-    };
+    let end_time = unsafe { unix_time_milliseconds_imported() };
 
     let duration = std::time::Duration::from_millis(end_time - start_time);
     (result, duration)

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -92,12 +92,13 @@ lazy_static! {
         extern "C" {
             fn unix_time_milliseconds_imported() -> u64;
         }
-        let unix_millis = unsafe {
-            unix_time_milliseconds_imported()
-        };
+        let unix_millis = unsafe { unix_time_milliseconds_imported() };
 
         use chrono::Datelike;
-        chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(unix_millis)).year()
+        chrono::DateTime::<chrono::Utc>::from(
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(unix_millis),
+        )
+        .year()
     };
 }
 

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -77,7 +77,7 @@ lazy_static! {
     pub(crate) static ref REFERENCE_YEAR: i32 = time::OffsetDateTime::now_utc().year();
 }
 
-#[cfg(all(target_arch = "wasm32", not(feature = "non-js")))]
+#[cfg(all(target_arch = "wasm32", not(feature = "custom_wasm_env")))]
 lazy_static! {
     pub(crate) static ref REFERENCE_YEAR: i32 = web_sys::js_sys::Date::new_0()
         .get_full_year()
@@ -85,7 +85,7 @@ lazy_static! {
         .unwrap();
 }
 
-#[cfg(all(target_arch = "wasm32", feature = "non-js"))]
+#[cfg(all(target_arch = "wasm32", feature = "custom_wasm_env"))]
 lazy_static! {
     pub(crate) static ref REFERENCE_YEAR: i32 = {
         #[link(wasm_import_module = "zxcvbn")]

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -77,12 +77,28 @@ lazy_static! {
     pub(crate) static ref REFERENCE_YEAR: i32 = time::OffsetDateTime::now_utc().year();
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "non-js")))]
 lazy_static! {
     pub(crate) static ref REFERENCE_YEAR: i32 = web_sys::js_sys::Date::new_0()
         .get_full_year()
         .try_into()
         .unwrap();
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "non-js"))]
+lazy_static! {
+    pub(crate) static ref REFERENCE_YEAR: i32 = {
+        #[link(wasm_import_module = "zxcvbn")]
+        extern "C" {
+            fn unix_time_milliseconds_imported() -> u64;
+        }
+        let unix_millis = unsafe {
+            unix_time_milliseconds_imported()
+        };
+
+        use chrono::Datelike;
+        chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(unix_millis)).year()
+    };
 }
 
 const MIN_YEAR_SPACE: i32 = 20;


### PR DESCRIPTION
## Background

Currently, on WASM targets, the `zxcvbn` crate can only be used if the host environment is JavaScript, such that functions such as `js_sys::new_0()::get_time()` would be available through bindings generated by e.g. wasm-bindgen.

## Rationale

Not all code compiled to WASM is run in a JavaScript runtime. 

One example is the [1Password Go SDK](https://github.com/1Password/onepassword-sdk-go), which uses [Extism](https://github.com/extism/go-sdk/blob/main/go.mod) to communicate with a [Wazero](https://github.com/tetratelabs/wazero) runtime, which does not have the JS bindings available.

For context, this project leverages a Rust core (where`zxcvbn` is used to determine the password's strength, when creating or updating 1Password items) compiled to WASM. Calls to it are made from the Go host env.

In situations where these system functions are not available, placeholders for it have to be injected into the runtime by the host.

In the Go code, injecting such a function would look similar to: 
https://github.com/1Password/onepassword-sdk-go/blob/main/internal/imported.go#L31-L38

## Thought process

This PR addresses this issue by allowing the host environment to inject its own implementation for the `now` function. It requires the environment to export a `unix_time_milliseconds_imported`, returning the unix timestamp in milliseconds.

This change is fully backwards compatible, and it requires that the consumers of the crate explicitly opt in to provide this custom implementation by activating the `custom_wasm_env` feature. In the absence of this feature, calls to zxcvbn would panic.

## How to test

Code review, to begin with, would be greatly appreciated. 

For functional review, I have put together a test repository where the new behaviour can be validated.

See testing notes in the README: https://github.com/hculea/zxcvbn-test

## Additional information

In the scope of this PR, I have also:
* removed the `getrandom` dependency from the wasm32 dependency tree, as it was not being used anywhere
* removed the `#![forbid(unsafe_code)]` linter, as injecting a custom function requires the execution of unsafe code

