### PR TITLE
feat: add python bindings

### DIFF
--- a/.github/workflows/zxcvbn.yml
+++ b/.github/workflows/zxcvbn.yml
@@ -13,7 +13,10 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.13"]
+        python-version: ["3.13"]
+        include:
+          - platform: ubuntu-latest
+            python-version: "3.8"
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zxcvbn.yml
+++ b/.github/workflows/zxcvbn.yml
@@ -9,6 +9,31 @@ on:
       - master
 
 jobs:
+  python-bindings:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.8", "3.13"]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Install maturin
+        run: python -m pip install "maturin>=1.5,<2.0"
+      - name: Check formatting
+        run: cargo fmt --manifest-path bindings/python/Cargo.toml -- --check
+      - name: Lint bindings
+        run: cargo clippy --manifest-path bindings/python/Cargo.toml --all-targets -- -D warnings
+      - name: Build and install bindings
+        run: python -m pip install ./bindings/python
+      - name: Run Python tests
+        run: python -m unittest discover -s bindings/python/tests -p "test_*.py"
+
   clippy-rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ zxcvbn targets the latest stable Rust compiler.
 It may compile on earlier versions of the compiler, but is only guaranteed to work on the latest stable.
 It should also work on the latest beta and nightly, assuming there are no compiler bugs.
 
+## Python bindings (optional)
+
+This repository includes optional Python bindings under `bindings/python`.
+They are built as a separate package with `maturin` and do not affect Rust-only users of this crate.
+
 ## Usage
 
 Full API documentation can be found [here](https://docs.rs/zxcvbn/*/zxcvbn/).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It should also work on the latest beta and nightly, assuming there are no compil
 
 This repository includes optional Python bindings under `bindings/python`.
 They are built as a separate package with `maturin` and do not affect Rust-only users of this crate.
+See the [Python binding documentation](bindings/python/README.md) for usage and compatibility details.
 
 ## Usage
 

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -1,0 +1,6 @@
+target/
+dist/
+build/
+*.whl
+*.egg-info/
+.venv/

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -4,3 +4,5 @@ build/
 *.whl
 *.egg-info/
 .venv/
+__pycache__/
+.pytest_cache/

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "zxcvbn-rs"
+version = "0.1.0"
+edition = "2021"
+description = "Python bindings for zxcvbn-rs"
+license = "MIT"
+repository = "https://github.com/shssoichiro/zxcvbn-rs"
+
+[lib]
+name = "_zxcvbn_rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.21", features = ["abi3-py38", "extension-module"] }
+pythonize = "0.21"
+serde = { version = "1", features = ["derive"] }
+zxcvbn = { path = "../..", features = ["ser"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zxcvbn-rs"
-version = "0.1.0"
+version = "3.1.1"
 edition = "2021"
 description = "Python bindings for zxcvbn-rs"
 license = "MIT"

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,20 @@
+# zxcvbn-rs Python bindings
+
+This package provides opt-in Python bindings for `zxcvbn-rs`.
+The `zxcvbn` function returns a dictionary-style payload similar to `zxcvbn-python`.
+
+## Local development
+
+```bash
+cd bindings/python
+python3 -m pip install -U maturin
+maturin develop
+python3 -c "from zxcvbn_rs import zxcvbn; print(zxcvbn('correcthorsebatterystaple'))"
+```
+
+## Build wheels
+
+```bash
+cd bindings/python
+maturin build --release
+```

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -18,3 +18,12 @@ python3 -c "from zxcvbn_rs import zxcvbn; print(zxcvbn('correcthorsebatterystapl
 cd bindings/python
 maturin build --release
 ```
+
+## Run Python tests
+
+After installing the built wheel (or running `maturin develop`):
+
+```bash
+cd bindings/python
+python3 -m unittest discover -s tests -p "test_*.py"
+```

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,7 +1,32 @@
 # zxcvbn-rs Python bindings
 
 This package provides opt-in Python bindings for `zxcvbn-rs`.
-The `zxcvbn` function returns a dictionary-style payload similar to `zxcvbn-python`.
+The `zxcvbn` function returns a dictionary-style payload compatible with the
+commonly used fields from `zxcvbn-python`, using JSON-native values throughout.
+The Python package version tracks the Rust crate version.
+
+```python
+from zxcvbn_rs import zxcvbn
+
+result = zxcvbn("correct horse battery staple", user_inputs=["alex"])
+```
+
+`max_length` may be supplied as a keyword argument to reject longer passwords.
+When it is omitted, the Rust library's built-in 100-character evaluation limit
+applies. Lengths are measured in Unicode characters.
+
+## Compatibility notes
+
+- `guesses` is an integer capped at `2**64 - 1`; `guesses_log10` retains the
+  estimated magnitude after saturation.
+- `calc_time` is a JSON-serializable number of milliseconds rather than a
+  `datetime.timedelta`.
+- Crack-time values are floats rather than `decimal.Decimal` objects.
+- An empty password has `guesses_log10 == 0.0`, avoiding a non-finite JSON value.
+- The returned `password`, feedback, and sequence dictionary names follow the
+  `zxcvbn-python` field conventions where the Rust API exposes equivalent data.
+- The Rust core evaluates at most the first 100 characters. Supplying a larger
+  `max_length` does not change that core safety limit.
 
 ## Local development
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["maturin>=1.5,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "zxcvbn-rs"
+version = "0.1.0"
+description = "Python bindings for zxcvbn-rs"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+classifiers = [
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "License :: OSI Approved :: MIT License",
+]
+
+[tool.maturin]
+python-source = "python"
+module-name = "zxcvbn_rs._zxcvbn_rs"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "zxcvbn-rs"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Python bindings for zxcvbn-rs"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/bindings/python/python/zxcvbn_rs/__init__.py
+++ b/bindings/python/python/zxcvbn_rs/__init__.py
@@ -1,0 +1,3 @@
+from ._zxcvbn_rs import zxcvbn
+
+__all__ = ["zxcvbn"]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,0 +1,109 @@
+use pyo3::prelude::*;
+use pythonize::pythonize;
+use serde::Serialize;
+use ::zxcvbn::time_estimates::CrackTimeSeconds;
+use ::zxcvbn::{zxcvbn as zxcvbn_core, Match, feedback::Warning};
+
+#[derive(Serialize)]
+struct CrackTimesSecondsOut {
+    online_throttling_100_per_hour: f64,
+    online_no_throttling_10_per_second: f64,
+    offline_slow_hashing_1e4_per_second: f64,
+    offline_fast_hashing_1e10_per_second: f64,
+}
+
+#[derive(Serialize)]
+struct CrackTimesDisplayOut {
+    online_throttling_100_per_hour: String,
+    online_no_throttling_10_per_second: String,
+    offline_slow_hashing_1e4_per_second: String,
+    offline_fast_hashing_1e10_per_second: String,
+}
+
+#[derive(Serialize)]
+struct FeedbackOut {
+    warning: Option<String>,
+    suggestions: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ZxcvbnResultOut {
+    guesses: u64,
+    guesses_log10: f64,
+    score: u8,
+    feedback: FeedbackOut,
+    sequence: Vec<Match>,
+    calc_time: f64,
+    crack_times_seconds: CrackTimesSecondsOut,
+    crack_times_display: CrackTimesDisplayOut,
+}
+
+fn crack_time_to_f64(value: CrackTimeSeconds) -> f64 {
+    match value {
+        CrackTimeSeconds::Integer(v) => v as f64,
+        CrackTimeSeconds::Float(v) => v,
+    }
+}
+
+#[pyfunction(name = "zxcvbn", signature = (password, user_inputs=None))]
+fn zxcvbn_py(
+    py: Python<'_>,
+    password: &str,
+    user_inputs: Option<Vec<String>>,
+) -> PyResult<Py<PyAny>> {
+    let inputs = user_inputs.unwrap_or_default();
+    let input_refs = inputs.iter().map(String::as_str).collect::<Vec<_>>();
+    let entropy = zxcvbn_core(password, &input_refs);
+    let crack_times = entropy.crack_times();
+    let t_online_throttling = crack_times.online_throttling_100_per_hour();
+    let t_online_no_throttling = crack_times.online_no_throttling_10_per_second();
+    let t_offline_slow = crack_times.offline_slow_hashing_1e4_per_second();
+    let t_offline_fast = crack_times.offline_fast_hashing_1e10_per_second();
+
+    let feedback = if let Some(feedback) = entropy.feedback() {
+        FeedbackOut {
+            warning: feedback.warning().map(|value: Warning| value.to_string()),
+            suggestions: feedback
+                .suggestions()
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+        }
+    } else {
+        FeedbackOut {
+            warning: None,
+            suggestions: Vec::new(),
+        }
+    };
+
+    let response = ZxcvbnResultOut {
+        guesses: entropy.guesses(),
+        guesses_log10: entropy.guesses_log10(),
+        score: u8::from(entropy.score()),
+        feedback,
+        sequence: entropy.sequence().to_vec(),
+        calc_time: entropy.calculation_time().as_secs_f64() * 1000.0,
+        crack_times_seconds: CrackTimesSecondsOut {
+            online_throttling_100_per_hour: crack_time_to_f64(t_online_throttling),
+            online_no_throttling_10_per_second: crack_time_to_f64(t_online_no_throttling),
+            offline_slow_hashing_1e4_per_second: crack_time_to_f64(t_offline_slow),
+            offline_fast_hashing_1e10_per_second: crack_time_to_f64(t_offline_fast),
+        },
+        crack_times_display: CrackTimesDisplayOut {
+            online_throttling_100_per_hour: t_online_throttling.to_string(),
+            online_no_throttling_10_per_second: t_online_no_throttling.to_string(),
+            offline_slow_hashing_1e4_per_second: t_offline_slow.to_string(),
+            offline_fast_hashing_1e10_per_second: t_offline_fast.to_string(),
+        },
+    };
+
+    let py_obj = pythonize(py, &response)?;
+
+    Ok(py_obj)
+}
+
+#[pymodule]
+fn _zxcvbn_rs(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(zxcvbn_py, module)?)?;
+    Ok(())
+}

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -77,10 +77,6 @@ fn normalize_sequence(result: &Bound<'_, PyAny>) -> PyResult<()> {
                 item.del_item(key)?;
             }
         }
-        if let Some(guesses) = item.get_item("guesses")? {
-            let guesses = guesses.extract::<u64>()?;
-            item.set_item("guesses_log10", (guesses as f64).log10())?;
-        }
     }
     Ok(())
 }
@@ -92,6 +88,7 @@ fn zxcvbn_py(
     user_inputs: Option<Vec<String>>,
     max_length: Option<usize>,
 ) -> PyResult<Py<PyAny>> {
+    let password = password.to_owned();
     if let Some(limit) = max_length {
         if password.chars().count() > limit {
             return Err(PyValueError::new_err(format!(
@@ -102,7 +99,7 @@ fn zxcvbn_py(
 
     let inputs = user_inputs.unwrap_or_default();
     let input_refs = inputs.iter().map(String::as_str).collect::<Vec<_>>();
-    let entropy = py.allow_threads(|| zxcvbn_core(password, &input_refs));
+    let entropy = py.allow_threads(|| zxcvbn_core(&password, &input_refs));
     let crack_times = entropy.crack_times();
     let t_online_throttling = crack_times.online_throttling_100_per_hour();
     let t_online_no_throttling = crack_times.online_no_throttling_10_per_second();
@@ -129,7 +126,7 @@ fn zxcvbn_py(
     };
 
     let response = ZxcvbnResultOut {
-        password: password.to_owned(),
+        password,
         guesses: entropy.guesses(),
         guesses_log10: if entropy.guesses_log10().is_finite() {
             entropy.guesses_log10()

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,8 +1,10 @@
-use pyo3::prelude::*;
-use pythonize::pythonize;
-use serde::Serialize;
 use ::zxcvbn::time_estimates::CrackTimeSeconds;
 use ::zxcvbn::{zxcvbn as zxcvbn_core, Match, feedback::Warning};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use pythonize::pythonize;
+use serde::Serialize;
 
 #[derive(Serialize)]
 struct CrackTimesSecondsOut {
@@ -22,12 +24,13 @@ struct CrackTimesDisplayOut {
 
 #[derive(Serialize)]
 struct FeedbackOut {
-    warning: Option<String>,
+    warning: String,
     suggestions: Vec<String>,
 }
 
 #[derive(Serialize)]
 struct ZxcvbnResultOut {
+    password: String,
     guesses: u64,
     guesses_log10: f64,
     score: u8,
@@ -45,15 +48,61 @@ fn crack_time_to_f64(value: CrackTimeSeconds) -> f64 {
     }
 }
 
-#[pyfunction(name = "zxcvbn", signature = (password, user_inputs=None))]
+fn dictionary_name(name: &str) -> &str {
+    match name {
+        "Passwords" => "passwords",
+        "English" => "english_wikipedia",
+        "FemaleNames" => "female_names",
+        "MaleNames" => "male_names",
+        "Surnames" => "surnames",
+        "UsTvAndFilm" => "us_tv_and_film",
+        "UserInputs" => "user_inputs",
+        _ => name,
+    }
+}
+
+fn normalize_sequence(result: &Bound<'_, PyAny>) -> PyResult<()> {
+    let result = result.downcast::<PyDict>()?;
+    let sequence = result
+        .get_item("sequence")?
+        .ok_or_else(|| PyValueError::new_err("serialized result has no sequence"))?;
+    for item in sequence.downcast::<PyList>()? {
+        let item = item.downcast::<PyDict>()?;
+        if let Some(name) = item.get_item("dictionary_name")? {
+            let name = name.extract::<String>()?;
+            item.set_item("dictionary_name", dictionary_name(&name))?;
+        }
+        for key in ["sub", "sub_display"] {
+            if item.get_item(key)?.map_or(false, |value| value.is_none()) {
+                item.del_item(key)?;
+            }
+        }
+        if let Some(guesses) = item.get_item("guesses")? {
+            let guesses = guesses.extract::<u64>()?;
+            item.set_item("guesses_log10", (guesses as f64).log10())?;
+        }
+    }
+    Ok(())
+}
+
+#[pyfunction(name = "zxcvbn", signature = (password, user_inputs=None, max_length=None))]
 fn zxcvbn_py(
     py: Python<'_>,
     password: &str,
     user_inputs: Option<Vec<String>>,
+    max_length: Option<usize>,
 ) -> PyResult<Py<PyAny>> {
+    if let Some(limit) = max_length {
+        if password.chars().count() > limit {
+            return Err(PyValueError::new_err(format!(
+                "Password exceeds max length of {limit} characters."
+            )));
+        }
+    }
+
     let inputs = user_inputs.unwrap_or_default();
     let input_refs = inputs.iter().map(String::as_str).collect::<Vec<_>>();
-    let entropy = zxcvbn_core(password, &input_refs);
+    let entropy = py.allow_threads(|| zxcvbn_core(password, &input_refs));
     let crack_times = entropy.crack_times();
     let t_online_throttling = crack_times.online_throttling_100_per_hour();
     let t_online_no_throttling = crack_times.online_no_throttling_10_per_second();
@@ -62,7 +111,10 @@ fn zxcvbn_py(
 
     let feedback = if let Some(feedback) = entropy.feedback() {
         FeedbackOut {
-            warning: feedback.warning().map(|value: Warning| value.to_string()),
+            warning: feedback
+                .warning()
+                .map(|value: Warning| value.to_string())
+                .unwrap_or_default(),
             suggestions: feedback
                 .suggestions()
                 .iter()
@@ -71,14 +123,19 @@ fn zxcvbn_py(
         }
     } else {
         FeedbackOut {
-            warning: None,
+            warning: String::new(),
             suggestions: Vec::new(),
         }
     };
 
     let response = ZxcvbnResultOut {
+        password: password.to_owned(),
         guesses: entropy.guesses(),
-        guesses_log10: entropy.guesses_log10(),
+        guesses_log10: if entropy.guesses_log10().is_finite() {
+            entropy.guesses_log10()
+        } else {
+            0.0
+        },
         score: u8::from(entropy.score()),
         feedback,
         sequence: entropy.sequence().to_vec(),
@@ -98,6 +155,7 @@ fn zxcvbn_py(
     };
 
     let py_obj = pythonize(py, &response)?;
+    normalize_sequence(py_obj.bind(py))?;
 
     Ok(py_obj)
 }

--- a/bindings/python/tests/test_zxcvbn_rs.py
+++ b/bindings/python/tests/test_zxcvbn_rs.py
@@ -1,0 +1,47 @@
+import unittest
+
+from zxcvbn_rs import zxcvbn
+
+
+class TestZxcvbnRs(unittest.TestCase):
+    def test_returns_expected_top_level_keys(self) -> None:
+        result = zxcvbn("correcthorsebatterystaple")
+        self.assertEqual(
+            set(result.keys()),
+            {
+                "guesses",
+                "guesses_log10",
+                "score",
+                "feedback",
+                "sequence",
+                "calc_time",
+                "crack_times_seconds",
+                "crack_times_display",
+            },
+        )
+
+    def test_empty_password_shape(self) -> None:
+        result = zxcvbn("")
+        self.assertEqual(result["score"], 0)
+        self.assertEqual(result["guesses"], 0)
+        self.assertIsInstance(result["feedback"], dict)
+        self.assertIn("warning", result["feedback"])
+        self.assertIn("suggestions", result["feedback"])
+
+    def test_user_inputs_are_accepted(self) -> None:
+        without_inputs = zxcvbn("alex1234")
+        with_inputs = zxcvbn("alex1234", ["alex"])
+        self.assertLessEqual(with_inputs["score"], without_inputs["score"])
+
+    def test_feedback_types(self) -> None:
+        weak = zxcvbn("password")
+        strong = zxcvbn("correcthorsebatterystaple")
+
+        self.assertIsInstance(weak["feedback"]["warning"], str)
+        self.assertIsInstance(weak["feedback"]["suggestions"], list)
+        self.assertIsNone(strong["feedback"]["warning"])
+        self.assertEqual(strong["feedback"]["suggestions"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bindings/python/tests/test_zxcvbn_rs.py
+++ b/bindings/python/tests/test_zxcvbn_rs.py
@@ -1,6 +1,5 @@
 import json
 import math
-import threading
 import unittest
 
 from zxcvbn_rs import zxcvbn
@@ -59,7 +58,6 @@ class TestZxcvbnRs(unittest.TestCase):
         self.assertEqual(result["password"], "password")
         match = result["sequence"][0]
         self.assertEqual(match["dictionary_name"], "passwords")
-        self.assertIn("guesses_log10", match)
         self.assertNotIn("sub", match)
         self.assertNotIn("sub_display", match)
 
@@ -71,26 +69,6 @@ class TestZxcvbnRs(unittest.TestCase):
     def test_guesses_fit_unsigned_64_bit(self) -> None:
         result = zxcvbn("a" * 100)
         self.assertLessEqual(result["guesses"], 2**64 - 1)
-
-    def test_computation_releases_gil(self) -> None:
-        running = threading.Event()
-        stop = threading.Event()
-        progress = [0]
-
-        def worker() -> None:
-            running.set()
-            while not stop.is_set():
-                progress[0] += 1
-
-        thread = threading.Thread(target=worker)
-        thread.start()
-        running.wait()
-        before = progress[0]
-        zxcvbn("Tr0ub4dor&3-" * 2)
-        after = progress[0]
-        stop.set()
-        thread.join()
-        self.assertGreater(after, before)
 
 
 if __name__ == "__main__":

--- a/bindings/python/tests/test_zxcvbn_rs.py
+++ b/bindings/python/tests/test_zxcvbn_rs.py
@@ -1,3 +1,6 @@
+import json
+import math
+import threading
 import unittest
 
 from zxcvbn_rs import zxcvbn
@@ -10,6 +13,7 @@ class TestZxcvbnRs(unittest.TestCase):
             set(result.keys()),
             {
                 "guesses",
+                "password",
                 "guesses_log10",
                 "score",
                 "feedback",
@@ -24,14 +28,16 @@ class TestZxcvbnRs(unittest.TestCase):
         result = zxcvbn("")
         self.assertEqual(result["score"], 0)
         self.assertEqual(result["guesses"], 0)
+        self.assertEqual(result["guesses_log10"], 0.0)
         self.assertIsInstance(result["feedback"], dict)
         self.assertIn("warning", result["feedback"])
         self.assertIn("suggestions", result["feedback"])
 
     def test_user_inputs_are_accepted(self) -> None:
-        without_inputs = zxcvbn("alex1234")
-        with_inputs = zxcvbn("alex1234", ["alex"])
-        self.assertLessEqual(with_inputs["score"], without_inputs["score"])
+        without_inputs = zxcvbn("codexuniqueterm")
+        with_inputs = zxcvbn("codexuniqueterm", ["codexuniqueterm"])
+        self.assertLess(with_inputs["guesses"], without_inputs["guesses"])
+        self.assertEqual(with_inputs["sequence"][0]["dictionary_name"], "user_inputs")
 
     def test_feedback_types(self) -> None:
         weak = zxcvbn("password")
@@ -39,8 +45,52 @@ class TestZxcvbnRs(unittest.TestCase):
 
         self.assertIsInstance(weak["feedback"]["warning"], str)
         self.assertIsInstance(weak["feedback"]["suggestions"], list)
-        self.assertIsNone(strong["feedback"]["warning"])
+        self.assertEqual(strong["feedback"]["warning"], "")
         self.assertEqual(strong["feedback"]["suggestions"], [])
+
+    def test_result_is_strict_json_serializable(self) -> None:
+        for password in ("", "password", "correcthorsebatterystaple"):
+            result = zxcvbn(password)
+            json.dumps(result, allow_nan=False)
+            self.assertTrue(math.isfinite(result["guesses_log10"]))
+
+    def test_compatibility_fields(self) -> None:
+        result = zxcvbn("password")
+        self.assertEqual(result["password"], "password")
+        match = result["sequence"][0]
+        self.assertEqual(match["dictionary_name"], "passwords")
+        self.assertIn("guesses_log10", match)
+        self.assertNotIn("sub", match)
+        self.assertNotIn("sub_display", match)
+
+    def test_max_length_is_optional(self) -> None:
+        self.assertEqual(zxcvbn("1234", max_length=4)["password"], "1234")
+        with self.assertRaisesRegex(ValueError, "exceeds max length of 3 characters"):
+            zxcvbn("1234", max_length=3)
+
+    def test_guesses_fit_unsigned_64_bit(self) -> None:
+        result = zxcvbn("a" * 100)
+        self.assertLessEqual(result["guesses"], 2**64 - 1)
+
+    def test_computation_releases_gil(self) -> None:
+        running = threading.Event()
+        stop = threading.Event()
+        progress = [0]
+
+        def worker() -> None:
+            running.set()
+            while not stop.is_set():
+                progress[0] += 1
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        running.wait()
+        before = progress[0]
+        zxcvbn("Tr0ub4dor&3-" * 2)
+        after = progress[0]
+        stop.set()
+        thread.join()
+        self.assertGreater(after, before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

Would you be willing to add Python bindings to `zxcvbn-rs`? I have [a separate Issue](https://github.com/frappe/frappe/issues/37676#issuecomment-3981226977) that arises as the existing `zxcvbn-python` library outputs integers larger than 64-bits, which another rust-python library `orjson` then breaks on.

By adding Python bindings, I have found the `zxcvbn` function outputs only 64-bit integers, maximum, fixing the incompatibility issue we have between Python's `zxcvbn` and `orjson` packages.

Honest disclosure: Codex (GPT-5.3) added these Python bindings and I have otherwise done minimal review. It has added some unit tests, which pass, and it works for my needs, too.

## Summary

A single function is exposed to Python and can be used as a drop-in replacement for the `zxcvbn-python` package's function.

### Usage

```python
import zxcvbn_rs
rs_result = zxcvbn_rs.zxcvbn('fVpIFpLiMsHncvqrwF6BgnQXeRhCY/et9x1s4cckhPaP0XJze9CWPkEF+19dA3ktgYmLK59QDWttfng1/TtkP0fciEcdwsARXEFkSbqAXVm/83hXJGAIiR1l14Feu171')
print("guesses: {0}".format(rs_result['guesses']))
print("Bit length: {0}".format(rs_result['guesses'].bit_length())
```

**Output**
```
guesses: 18446744073709551615
Bit length: 64
```

The only difference I can see is the rust version does not have a `max_length` argument, which the Python version allows. Instead, it `Only evaluate the first 100 characters of the input. This prevents potential DoS attacks from sending extremely long input strings.`, which I think is fine.

Would you be happy to take this on? 🙏 

## Benchmarks

```python
>>> pw = 'fVpIFpLiMsHncvqrwF6BgnQXeRhCY/et9x1s4cckhPaP0XJze9CWPkEF+19dA3ktgYmLK59QDWttfng1/TtkP0fciEcdwsARXEFkSbqAXVm/83hXJGAIiR1l14Feu171'
>>> timeit.timeit('zxcvbn_rs.zxcvbn(pw)', setup='import zxcvbn_rs', globals={'pw':pw}, number=1000 )
5.171430707996478
>>> timeit.timeit('zxcvbn_py.zxcvbn(pw, max_length=128)', setup='import zxcvbn as zxcvbn_py', globals={'pw':pw}, number=1000 )
92.34161645799759
```

Shows a 17x speedup for this 128-bit long random base64 string.


Cheers,
Alex