### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 derive_builder = { version = "0.20", optional = true }
-fancy-regex = "0.18"
-itertools = "0.14"
+fancy-regex = "0.19.0"
+itertools = "0.15.0"
 lazy_static = "1.3"
 regex = "1"
 time = { version = "0.3" }


### PR DESCRIPTION
Updates `itertools` to `0.15.0` and `fancy-regex` to `0.19.0`.